### PR TITLE
Website fixes

### DIFF
--- a/src/components/landing/Hero/Hero.module.css
+++ b/src/components/landing/Hero/Hero.module.css
@@ -1,12 +1,12 @@
 .arrow {
-  opacity: 0;
   position: absolute;
-  left: 50vw;
-  top: 80vh;
-  transform-origin: 50% 80%;
-  transform: translate3d(-50%, -50%, 0);
+  opacity: 0;
+  left: 50%;
+  bottom: 40%;
+  transform: translateX(-50%);
   color: black;
 }
+
 .arrow:before,
 .arrow:after {
   background: black;
@@ -14,19 +14,17 @@
   display: block;
   height: 3px;
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 10px;
+  left: 50%;
   width: 30px;
 }
 
 .arrow:before {
-  transform: rotate(45deg) translateX(-23%);
-  transform-origin: top left;
+  transform: translateX(calc(-50% - 10px)) rotate(45deg);
 }
 
 .arrow:after {
-  transform: rotate(-45deg) translateX(23%);
-  transform-origin: top right;
+  transform: translateX(calc(-50% + 10px)) rotate(-45deg);
 }
 
 .arrowfirst {
@@ -46,6 +44,6 @@
   }
   100% {
     opacity: 0;
-    top: 75%;
+    bottom: 15%;
   }
 }

--- a/src/components/landing/Hero/Hero.module.css
+++ b/src/components/landing/Hero/Hero.module.css
@@ -44,6 +44,6 @@
   }
   100% {
     opacity: 0;
-    bottom: 15%;
+    bottom: 35%;
   }
 }

--- a/src/components/shared/Navbar/ACMLogo.tsx
+++ b/src/components/shared/Navbar/ACMLogo.tsx
@@ -10,9 +10,10 @@ const ACMLogo = () => {
       disableRipple
       sx={{
         transition: "transform 0.3s ease-in-out",
+        backgroundColor: "transparent",
         "&:hover": {
           transform: "scale(1.05)",
-          backgroundColor: "#fff",
+          backgroundColor: "transparent",
         },
         height: "70px",
         width: "auto",


### PR DESCRIPTION
Two fixes:

1. Fixed the weird behavior of the Hero arrows on the homepage (e.g. they started moving in the opposite direction when the page was resized). Credit to @ken-tummada, I copied over his Hero arrow code from the About Us page and changed it a little so that there are two arrows and moved the arrows in the correct position.
2. The background of the ACM logo in the nav bar was set to white. This meant that on the about us page, which has a non-white background, when I hovered over the ACM logo the white background expanded in the page. This doesn't look good so I fixed it by changing the background to transparent.
<img width="414" alt="image" src="https://github.com/user-attachments/assets/1766dea4-fa57-4c37-b385-92a5b12cd3be" />
