### PR TITLE
removing banner and moving intern page to a tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "fix": "yarn lint:fix && yarn prettier:fix",
     "lint:fix": "next lint --fix",
     "lint": "next lint",
     "prettier:fix": "prettier --write .",

--- a/src/app/interns/page.tsx
+++ b/src/app/interns/page.tsx
@@ -20,10 +20,7 @@ export default function Home() {
     <main>
       <div className="flex flex-col align-center">
         <Navbar />
-        <Banner
-          inputLink="https://forms.gle/s5SSAPMMkk2oBL9V7"
-          inputText="Click here to apply!"
-        />
+        <Banner inputText="Applications have now closed." />
 
         <div className="flex flex-col align-center items-center">
           <InternHeroSection />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,10 +12,6 @@ export default function Home() {
     <main>
       <div className="flex flex-col align-center">
         <Navbar />
-        <Banner
-          inputText="Apply to be an ACM Intern Here!"
-          inputLink="/interns"
-        />
         <Hero />
         <AboutBlurb />
         <Branches />

--- a/src/components/shared/Navbar/ButtonLabels.ts
+++ b/src/components/shared/Navbar/ButtonLabels.ts
@@ -1,6 +1,33 @@
-export const ButtonLabels = {
-  about: "About Us",
-  branches: "Branches",
-  events: "Events",
-  faq: "FAQ",
-};
+interface ButtonLabelType {
+  key: string;
+  buttonLabelString: string;
+  routingLink: string;
+}
+
+export const ButtonLabels: ButtonLabelType[] = [
+  {
+    key: "about",
+    buttonLabelString: "About Us",
+    routingLink: "/#about",
+  },
+  {
+    key: "branches",
+    buttonLabelString: "Branches",
+    routingLink: "/#branches",
+  },
+  {
+    key: "events",
+    buttonLabelString: "Events",
+    routingLink: "/#events",
+  },
+  {
+    key: "faq",
+    buttonLabelString: "FAQ",
+    routingLink: "/#faq",
+  },
+  {
+    key: "interns",
+    buttonLabelString: "Interns",
+    routingLink: "/interns",
+  },
+];

--- a/src/components/shared/Navbar/Navbar.tsx
+++ b/src/components/shared/Navbar/Navbar.tsx
@@ -29,9 +29,9 @@ const Navbar = () => {
         <div className="flex items-center">
           {/* Desktop Navigation - hidden on screens smaller than 'lg' (1024px) */}
           <div className="hidden lg:flex gap-20">
-            {Object.entries(ButtonLabels).map(([key, value]) => (
-              <Link href={`/#${key}`} key={key}>
-                <StyledNavbarButton label={value} />
+            {ButtonLabels.map(({ key, buttonLabelString, routingLink }) => (
+              <Link href={routingLink} key={key}>
+                <StyledNavbarButton label={buttonLabelString} />
               </Link>
             ))}
           </div>
@@ -44,9 +44,9 @@ const Navbar = () => {
           <div className="w-64 p-4 flex flex-col items-center gap-[1rem]">
             <ACMLogo />
             <br />
-            {Object.entries(ButtonLabels).map(([key, value]) => (
-              <Link href={`/#${key}`} key={key} onClick={handleDrawerToggle}>
-                <StyledNavbarButton label={value} />
+            {ButtonLabels.map(({ key, buttonLabelString, routingLink }) => (
+              <Link href={routingLink} key={key} onClick={handleDrawerToggle}>
+                <StyledNavbarButton label={buttonLabelString} />
               </Link>
             ))}
           </div>


### PR DESCRIPTION
Intern applications are now closed! Removing the banner and moving the intern page to be routable via the navbar. Refactored some of the navbar button data types for more functionality in the dev exp.

Preview: https://acm-ucsb-rekm367nf-smmzhus-projects.vercel.app/